### PR TITLE
Add direct exchange example

### DIFF
--- a/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageDefinition.cs
+++ b/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageDefinition.cs
@@ -1,0 +1,19 @@
+using MassTransit;
+using Messaging.Common.Events;
+
+namespace Consumer.API.A.Consumer.ConsumeMessage.Direct;
+
+public class ConsumeDirectMessageDefinition : ConsumerDefinition<ConsumeDirectMessageHandler>
+{
+    protected override void ConfigureConsumer(
+        IReceiveEndpointConfigurator endpointConfigurator,
+        IConsumerConfigurator<ConsumeDirectMessageHandler> consumerConfigurator)
+    {
+        endpointConfigurator.ConfigureConsumeTopology = false;
+        endpointConfigurator.Bind<TestEvent>(x =>
+        {
+            x.ExchangeType = ExchangeType.Direct;
+            x.RoutingKey = "consumer.api.a";
+        });
+    }
+}

--- a/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageHandler.cs
+++ b/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageHandler.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using MassTransit;
+using Messaging.Common.Events;
+
+namespace Consumer.API.A.Consumer.ConsumeMessage.Direct;
+
+public class ConsumeDirectMessageHandler(ILogger<ConsumeDirectMessageHandler> logger) : IConsumer<TestEvent>
+{
+    public Task Consume(ConsumeContext<TestEvent> context)
+    {
+        logger.LogInformation("Direct TestEvent handled: {Event}", JsonSerializer.Serialize(context.Message));
+        return Task.CompletedTask;
+    }
+}

--- a/Consumer.API.A/Program.cs
+++ b/Consumer.API.A/Program.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Consumer.API.A.Consumer.ConsumeMessage.Fanout;
+using Consumer.API.A.Consumer.ConsumeMessage.Direct;
 using Messaging.Common.MassTransit;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,6 +9,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddMessageBroker(builder.Configuration, Assembly.GetExecutingAssembly());
 builder.Services.AddOpenApi();
 builder.Services.AddScoped<ConsumeFanoutMessageHandler>();
+builder.Services.AddScoped<ConsumeDirectMessageHandler>();
 
 var app = builder.Build();
 

--- a/Producer.API/Producer.API.http
+++ b/Producer.API/Producer.API.http
@@ -9,3 +9,14 @@ Content-Type: application/json
   "content": "Test fanout message from HTTP file"
 }
 
+### 📨 Send Direct Message
+POST http://localhost:5003/send/direct
+Content-Type: application/json
+
+{
+  "userName": "jane.doe",
+  "emailAddress": "jane@example.com",
+  "zipCode": "10117",
+  "content": "Test direct message from HTTP file"
+}
+

--- a/Producer.API/Producer/SendMessage/Direct/SendDirectMessageEndpoint.cs
+++ b/Producer.API/Producer/SendMessage/Direct/SendDirectMessageEndpoint.cs
@@ -1,0 +1,24 @@
+using Carter;
+using Messaging.Common.Events;
+
+namespace Producer.API.Producer.SendMessage.Direct;
+
+public class SendDirectMessageEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/send/direct", async (
+                TestEvent request,
+                SendDirectMessageHandler handler,
+                CancellationToken ct) =>
+            {
+                await handler.HandleAsync(request, ct);
+                return Results.Accepted();
+            })
+            .WithName("SendDirectMessage")
+            .Produces(200)
+            .ProducesProblem(400)
+            .WithSummary("Send Direct Message")
+            .WithDescription("Send Direct Message");
+    }
+}

--- a/Producer.API/Producer/SendMessage/Direct/SendDirectMessageHandler.cs
+++ b/Producer.API/Producer/SendMessage/Direct/SendDirectMessageHandler.cs
@@ -1,0 +1,15 @@
+using MassTransit;
+using Messaging.Common.Events;
+using Producer.API.Producer.SendMessage.Extensions;
+
+namespace Producer.API.Producer.SendMessage.Direct;
+
+public class SendDirectMessageHandler(ISendEndpointProvider provider, ILogger<SendDirectMessageHandler> logger)
+{
+    private const string RoutingKey = "consumer.api.a";
+
+    public async Task HandleAsync(TestEvent message, CancellationToken ct)
+    {
+        await provider.SendToDirectExchange(message, RoutingKey, logger, ct);
+    }
+}

--- a/Producer.API/Program.cs
+++ b/Producer.API/Program.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Carter;
 using Messaging.Common.MassTransit;
 using Producer.API.Producer.SendMessage.Fanout;
+using Producer.API.Producer.SendMessage.Direct;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,6 +12,7 @@ builder.Services.AddOpenApi();
 builder.Services.AddMessageBroker(builder.Configuration, Assembly.GetExecutingAssembly());
 
 builder.Services.AddScoped<SendFanoutMessageHandler>();
+builder.Services.AddScoped<SendDirectMessageHandler>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- implement ConsumeDirectMessageHandler and definition binding to `consumer.api.a`
- implement SendDirectMessageHandler and endpoint to send to direct exchange
- register direct handlers in Producer and Consumer
- document sample request in `Producer.API.http`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68752d31a63c832db88cca47a415f3af