### PR TITLE
Fix Bind method in RabbitMQ consumer definition

### DIFF
--- a/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageDefinition.cs
+++ b/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageDefinition.cs
@@ -10,10 +10,14 @@ public class ConsumeDirectMessageDefinition : ConsumerDefinition<ConsumeDirectMe
         IConsumerConfigurator<ConsumeDirectMessageHandler> consumerConfigurator)
     {
         endpointConfigurator.ConfigureConsumeTopology = false;
-        endpointConfigurator.Bind<TestEvent>(x =>
+
+        if (endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rabbitConfigurator)
         {
-            x.ExchangeType = ExchangeType.Direct;
-            x.RoutingKey = "consumer.api.a";
-        });
+            rabbitConfigurator.Bind<TestEvent>(x =>
+            {
+                x.ExchangeType = ExchangeType.Direct;
+                x.RoutingKey = "consumer.api.a";
+            });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- properly cast endpoint configurator to access RabbitMQ specific `Bind` method in `ConsumeDirectMessageDefinition`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687544606c34832d960696b9e905fe41