### PR TITLE
Expose bus configurator hook and adjust consumer

### DIFF
--- a/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageDefinition.cs
+++ b/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageDefinition.cs
@@ -6,6 +6,7 @@ namespace Consumer.API.A.Consumer.ConsumeMessage.Direct;
 public class ConsumeDirectMessageDefinition : ConsumerDefinition<ConsumeDirectMessageHandler>
 {
     protected override void ConfigureConsumer(
+        IReceiveEndpointBuilder builder,
         IReceiveEndpointConfigurator endpointConfigurator,
         IConsumerConfigurator<ConsumeDirectMessageHandler> consumerConfigurator)
     {
@@ -18,6 +19,11 @@ public class ConsumeDirectMessageDefinition : ConsumerDefinition<ConsumeDirectMe
                 x.ExchangeType = ExchangeType.Direct;
                 x.RoutingKey = "consumer.api.a";
             });
+        }
+
+        if (builder is IRabbitMqBusFactoryConfigurator busConfigurator)
+        {
+            busConfigurator.Publish<TestEvent>(x => x.ExchangeType = ExchangeType.Direct);
         }
     }
 }

--- a/Messaging.Common/MassTransit/Extensions.cs
+++ b/Messaging.Common/MassTransit/Extensions.cs
@@ -7,8 +7,11 @@ namespace Messaging.Common.MassTransit;
 
 public static class Extensions
 {
-    public static IServiceCollection AddMessageBroker
-        (this IServiceCollection services, IConfiguration configuration, Assembly? assembly = null)
+    public static IServiceCollection AddMessageBroker(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        Assembly? assembly = null,
+        Action<IRabbitMqBusFactoryConfigurator, IBusRegistrationContext>? configure = null)
     {
         services.AddMassTransit(config =>
         {
@@ -24,6 +27,9 @@ public static class Extensions
                     host.Username(configuration["MessageBroker:UserName"] ?? string.Empty);
                     host.Password(configuration["MessageBroker:Password"] ?? string.Empty);
                 });
+
+                configure?.Invoke(configurator, context);
+
                 configurator.ConfigureEndpoints(context);
             });
         });


### PR DESCRIPTION
## Summary
- expose `IRabbitMqBusFactoryConfigurator` hook in `AddMessageBroker`
- bind direct exchange using the bus configurator in `ConsumeDirectMessageDefinition`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687546273680832dbc87b7187873e3b0