### PR TITLE
Fix direct consumer definition

### DIFF
--- a/Consumer.API.A/Consumer/ConsumeMessage/Direct/DirectExchangeBusConfigurator.cs
+++ b/Consumer.API.A/Consumer/ConsumeMessage/Direct/DirectExchangeBusConfigurator.cs
@@ -1,0 +1,13 @@
+using MassTransit;
+using Messaging.Common.Events;
+using Messaging.Common.MassTransit;
+
+namespace Consumer.API.A.Consumer.ConsumeMessage.Direct;
+
+public class DirectExchangeBusConfigurator : IRabbitMqBusConfigurator
+{
+    public void Configure(IRabbitMqBusFactoryConfigurator configurator, IBusRegistrationContext context)
+    {
+        configurator.Publish<TestEvent>(x => x.ExchangeType = ExchangeType.Direct);
+    }
+}

--- a/Consumer.API.A/Program.cs
+++ b/Consumer.API.A/Program.cs
@@ -7,6 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddMessageBroker(builder.Configuration, Assembly.GetExecutingAssembly());
+builder.Services.AddSingleton<IRabbitMqBusConfigurator, DirectExchangeBusConfigurator>();
 builder.Services.AddOpenApi();
 builder.Services.AddScoped<ConsumeFanoutMessageHandler>();
 builder.Services.AddScoped<ConsumeDirectMessageHandler>();

--- a/Messaging.Common/MassTransit/Extensions.cs
+++ b/Messaging.Common/MassTransit/Extensions.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using MassTransit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Messaging.Common.MassTransit;
 
@@ -27,6 +28,9 @@ public static class Extensions
                     host.Username(configuration["MessageBroker:UserName"] ?? string.Empty);
                     host.Password(configuration["MessageBroker:Password"] ?? string.Empty);
                 });
+
+                foreach (var busConfigurator in context.GetServices<IRabbitMqBusConfigurator>())
+                    busConfigurator.Configure(configurator, context);
 
                 configure?.Invoke(configurator, context);
 

--- a/Messaging.Common/MassTransit/IRabbitMqBusConfigurator.cs
+++ b/Messaging.Common/MassTransit/IRabbitMqBusConfigurator.cs
@@ -1,0 +1,8 @@
+namespace Messaging.Common.MassTransit;
+
+using MassTransit;
+
+public interface IRabbitMqBusConfigurator
+{
+    void Configure(IRabbitMqBusFactoryConfigurator configurator, IBusRegistrationContext context);
+}


### PR DESCRIPTION
## Summary
- expose bus configurator hook
- plug in direct exchange publish configuration via interface
- wire up bus configurators from MassTransit extension

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1045 does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687552e8a0e0832d957d2e76b0a155a2