### PR TITLE
Fix ConsumerDefinition signature for direct message handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ CodeCoverage/
 *.VisualState.xml
 TestResult.xml
 nunit-*.xml
+packages-microsoft-prod.deb

--- a/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageDefinition.cs
+++ b/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageDefinition.cs
@@ -1,14 +1,15 @@
 using MassTransit;
 using Messaging.Common.Events;
+using RabbitMQ.Client;
 
 namespace Consumer.API.A.Consumer.ConsumeMessage.Direct;
 
 public class ConsumeDirectMessageDefinition : ConsumerDefinition<ConsumeDirectMessageHandler>
 {
     protected override void ConfigureConsumer(
-        IReceiveEndpointBuilder builder,
         IReceiveEndpointConfigurator endpointConfigurator,
-        IConsumerConfigurator<ConsumeDirectMessageHandler> consumerConfigurator)
+        IConsumerConfigurator<ConsumeDirectMessageHandler> consumerConfigurator,
+        IRegistrationContext context)
     {
         endpointConfigurator.ConfigureConsumeTopology = false;
 
@@ -21,7 +22,7 @@ public class ConsumeDirectMessageDefinition : ConsumerDefinition<ConsumeDirectMe
             });
         }
 
-        if (builder is IRabbitMqBusFactoryConfigurator busConfigurator)
+        if (context is IRabbitMqBusFactoryConfigurator busConfigurator)
         {
             busConfigurator.Publish<TestEvent>(x => x.ExchangeType = ExchangeType.Direct);
         }


### PR DESCRIPTION
## Summary
- correct `ConsumeDirectMessageDefinition` override signature
- add missing `RabbitMQ.Client` using directive
- ignore `packages-microsoft-prod.deb`

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6875637bc1cc832da922d132147a3d85