### PR TITLE
Fix direct message binding

### DIFF
--- a/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageDefinition.cs
+++ b/Consumer.API.A/Consumer/ConsumeMessage/Direct/ConsumeDirectMessageDefinition.cs
@@ -16,11 +16,13 @@ public class ConsumeDirectMessageDefinition : ConsumerDefinition<ConsumeDirectMe
 
         if (endpointConfigurator is IRabbitMqReceiveEndpointConfigurator rabbitConfigurator)
         {
-            rabbitConfigurator.Bind<TestEvent>(x =>
-            {
-                x.ExchangeType = ExchangeType.Direct;
-                x.RoutingKey = RabbitMqRoutingKeys.ConsumerApiA;
-            });
+            rabbitConfigurator.Bind(
+                RabbitMqExchangeNames.TestEventDirect,
+                x =>
+                {
+                    x.ExchangeType = ExchangeType.Direct;
+                    x.RoutingKey = RabbitMqRoutingKeys.ConsumerApiA;
+                });
         }
     }
 }

--- a/Messaging.Common/Constants/RabbitMqExchangeNames.cs
+++ b/Messaging.Common/Constants/RabbitMqExchangeNames.cs
@@ -1,0 +1,6 @@
+namespace Messaging.Common.Constants;
+
+public static class RabbitMqExchangeNames
+{
+    public const string TestEventDirect = "test-event-direct";
+}

--- a/Producer.API/Producer/SendMessage/Direct/SendDirectMessageHandler.cs
+++ b/Producer.API/Producer/SendMessage/Direct/SendDirectMessageHandler.cs
@@ -11,6 +11,11 @@ public class SendDirectMessageHandler(ISendEndpointProvider provider, ILogger<Se
 
     public async Task HandleAsync(TestEvent message, CancellationToken ct)
     {
-        await provider.SendToDirectExchange(message, RoutingKey, logger, ct);
+        await provider.SendToDirectExchange(
+            message,
+            RoutingKey,
+            logger,
+            ct,
+            RabbitMqExchangeNames.TestEventDirect);
     }
 }

--- a/Producer.API/Producer/SendMessage/Extensions/SendToExchangeExtensions.cs
+++ b/Producer.API/Producer/SendMessage/Extensions/SendToExchangeExtensions.cs
@@ -5,12 +5,12 @@ namespace Producer.API.Producer.SendMessage.Extensions;
 
 public static class SendToExchangeExtensions
 {
-    public static Uri BuildExchangeUri<T>(string exchangeType, Dictionary<string, object> parameters)
+    public static Uri BuildExchangeUri<T>(string exchangeType, Dictionary<string, object> parameters, string? exchangeName = null)
     {
         var query = parameters.Count > 0
             ? "&" + string.Join("&", parameters.Select(kvp => $"{kvp.Key}={kvp.Value}"))
             : string.Empty;
-        return new Uri($"exchange:{typeof(T).Name}?type={exchangeType}{query}");
+        return new Uri($"exchange:{exchangeName ?? typeof(T).Name}?type={exchangeType}{query}");
     }
 
     public static async Task SendToDirectExchange<T>(
@@ -18,11 +18,13 @@ public static class SendToExchangeExtensions
         T message,
         string routingKey,
         ILogger logger,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? exchangeName = null)
     {
         var uri = BuildExchangeUri<T>(
             "direct",
-            new Dictionary<string, object> { ["routingKey"] = routingKey });
+            new Dictionary<string, object> { ["routingKey"] = routingKey },
+            exchangeName);
         await SendToUri(provider, message, uri, logger, ct);
     }
 
@@ -31,11 +33,13 @@ public static class SendToExchangeExtensions
         T message,
         string routingKey,
         ILogger logger,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? exchangeName = null)
     {
         var uri = BuildExchangeUri<T>(
             "topic",
-            new Dictionary<string, object> { ["routingKey"] = routingKey });
+            new Dictionary<string, object> { ["routingKey"] = routingKey },
+            exchangeName);
         await SendToUri(provider, message, uri, logger, ct);
     }
 
@@ -44,9 +48,10 @@ public static class SendToExchangeExtensions
         T message,
         Dictionary<string, object> headers,
         ILogger logger,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? exchangeName = null)
     {
-        var uri = BuildExchangeUri<T>("headers", headers);
+        var uri = BuildExchangeUri<T>("headers", headers, exchangeName);
         await SendToUri(provider, message, uri, logger, ct);
     }
 


### PR DESCRIPTION
## Summary
- add dedicated exchange constant
- bind `Consumer.API.A` to custom direct exchange
- include exchange name in direct-send helper
- use the custom exchange for direct sends

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6876495d92ac832d9d2569a914df2e4e